### PR TITLE
support target url with pathname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp
+node_modules

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -24,6 +24,7 @@ module.exports = function replaceOriginal(original, from, to) {
     if (url.origin === from.origin) {
       url.host = to.host;
       url.protocol = to.protocol;
+      url.pathname = to.pathname;
       meta.resolved = url.toString();
       replaced++;
     }

--- a/tests.js
+++ b/tests.js
@@ -28,6 +28,25 @@ describe('yarnlock-hostname-changer', function() {
     expect(total).to.eql(132);
   });
 
+  it('also works for target url with pathname', function() {
+    const original = fs.readFileSync(`/${FIXTURES}/yarn.lock`, 'UTF8');
+    const parsed = lockfile.parse(original);
+
+    expect(original).to.contain('https://registry.yarnpkg.com')
+    expect(original).to.not.contain('http://registry.iamstef.net/hey/stef');
+
+    const {
+      result,
+      total,
+      replaced
+    } = replacer(original, 'https://registry.yarnpkg.com', 'http://registry.iamstef.net/hey/stef');
+
+    expect(result).to.not.contain('https://registry.yarnpkg.com');
+    expect(result).to.contain('http://registry.iamstef.net/hey/stef');
+    expect(replaced).to.eql(132);
+    expect(total).to.eql(132);
+  });
+
   it('test CLI', function() {
     const TMP = __dirname + '/tmp';
 


### PR DESCRIPTION
I was using this and got`yarn.lcok` messed up, it's good if we can support this.

:grin::grin::grin: