### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "yarnlock-origin-changer": "./bin/yarnlock-origin-changer"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stefanpenner/yarnlock-origin-changer.git"
+  },
   "devDependencies": {
     "chai": "^4.2.0",
     "execa": "^5.0.0",


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* yarnlock-origin-changer